### PR TITLE
Change upload timeouts to 5 mins

### DIFF
--- a/core/src/main/scala/com/nulabinc/backlog/migration/common/modules/DefaultModule.scala
+++ b/core/src/main/scala/com/nulabinc/backlog/migration/common/modules/DefaultModule.scala
@@ -56,8 +56,10 @@ class DefaultModule(apiConfig: BacklogApiConfiguration) extends AbstractModule {
 
   private[this] def createBacklogAPIClient(iaah: IAAH): BacklogAPIClient = {
     val backlogPackageConfigure = new BacklogPackageConfigure(apiConfig.url)
-    val configure               = backlogPackageConfigure.apiKey(apiConfig.key)
-
+    val configure               = backlogPackageConfigure
+                                    .apiKey(apiConfig.key)
+                                    .connectionTimeout(300000)
+                                    .readTimeout(300000)
     new BacklogAPIClientImpl(configure, iaah)
   }
 

--- a/core/src/main/scala/com/nulabinc/backlog/migration/common/modules/ServiceInjector.scala
+++ b/core/src/main/scala/com/nulabinc/backlog/migration/common/modules/ServiceInjector.scala
@@ -17,7 +17,10 @@ object ServiceInjector {
     Guice.createInjector(new AbstractModule() {
       override def configure(): Unit = {
         val backlogPackageConfigure = new BacklogPackageConfigure(apiConfig.url)
-        val configure               = backlogPackageConfigure.apiKey(apiConfig.key)
+        val configure               = backlogPackageConfigure
+                                        .apiKey(apiConfig.key)
+                                        .connectionTimeout(300000)
+                                        .readTimeout(300000)
         val backlog                 = new BacklogAPIClientImpl(configure, apiConfig.iaah)
 
         bind(classOf[BacklogProjectKey]).toInstance(BacklogProjectKey(apiConfig.projectKey))


### PR DESCRIPTION
The default upload timeout of 30 seconds was often not enough for the bigger files, so changing it to 5 minutes